### PR TITLE
Add support for IPv6 authenticated logins

### DIFF
--- a/timescaledb/rootfs/etc/s6-overlay/s6-rc.d/init-addon/run
+++ b/timescaledb/rootfs/etc/s6-overlay/s6-rc.d/init-addon/run
@@ -31,6 +31,8 @@ initializeDataDirectory () {
 	
 	# Set Password protect IPv4 hosts by default
 	echo "host    all             all             0.0.0.0/0               md5" >> ${POSTGRES_DATA}/pg_hba.conf
+	# Set Password protect IPv6 hosts by default
+	echo "host    all             all             ::/0                    md5" >> ${POSTGRES_DATA}/pg_hba.conf
 	echo "local    all             all                                    md5" >> ${POSTGRES_DATA}/pg_hba.conf
 	echo "local    all             all                                   peer" >> ${POSTGRES_DATA}/pg_hba.conf
 	# Set Listen on all addresses (*)


### PR DESCRIPTION
# Proposed Changes

This PR updates the addon initialization to add support for IPv6 authenticated logins

## Related Issues

Fixes: https://github.com/expaso/hassos-addon-timescaledb/issues/58
