### PR TITLE
Fix pg_hba_config writing literal "null" and orphaned rules on clear

### DIFF
--- a/timescaledb/rootfs/etc/s6-overlay/s6-rc.d/init-addon/run
+++ b/timescaledb/rootfs/etc/s6-overlay/s6-rc.d/init-addon/run
@@ -310,10 +310,10 @@ if bashio::config.has_value 'max_connections'; then
 	bashio::log.info "done"
 fi
 
-# Apply user-provided PostgreSQL configuration overrides
-if bashio::config.has_value 'postgresql_config' || bashio::config.has_value 'pg_hba_config'; then
-	bashio::log.info "Applying user configuration overrides.."
-	chmod 707 "/usr/share/timescaledb/003_apply_user_config.sh"
-	/usr/share/timescaledb/003_apply_user_config.sh
-	bashio::log.info "done"
-fi
+# Always invoke the user-config script: even when both override blocks are
+# empty it still cleans up any previously written user-defined pg_hba.conf
+# rules so a cleared config is honored.
+bashio::log.info "Applying user configuration overrides.."
+chmod 707 "/usr/share/timescaledb/003_apply_user_config.sh"
+/usr/share/timescaledb/003_apply_user_config.sh
+bashio::log.info "done"

--- a/timescaledb/rootfs/usr/share/timescaledb/003_apply_user_config.sh
+++ b/timescaledb/rootfs/usr/share/timescaledb/003_apply_user_config.sh
@@ -33,13 +33,28 @@ FORBIDDEN_PARAMS=(
 is_forbidden_param() {
     local param="${1}"
     local forbidden
-    
+
     for forbidden in "${FORBIDDEN_PARAMS[@]}"; do
         if [[ "${param}" == "${forbidden}" ]]; then
             return 0
         fi
     done
     return 1
+}
+
+# Safely read an optional bashio config value.
+# bashio::config "key" "" collapses the empty-string default to the literal
+# string "null" (due to `${2:-null}` in bashio), which then gets written into
+# pg_hba.conf and rejected by PostgreSQL. Guard with has_value to return a true
+# empty string instead.
+optional_config() {
+    local key="${1}"
+    local fallback="${2:-}"
+    if bashio::config.has_value "${key}"; then
+        bashio::config "${key}"
+    else
+        printf "%s" "${fallback}"
+    fi
 }
 
 # Apply postgresql.conf configuration
@@ -83,41 +98,45 @@ apply_postgresql_config() {
 
 # Apply pg_hba.conf configuration
 apply_pg_hba_config() {
-    if ! bashio::config.has_value 'pg_hba_config'; then
-        return 0
-    fi
-    
-    bashio::log.info "Applying pg_hba.conf authentication rules..."
-
-    # Remove any previously written user-defined rules to avoid duplicates on restart
+    # Always clean up previously written user-defined rules first so that
+    # clearing pg_hba_config in the addon UI also removes any orphaned rules
+    # (notably important to recover from a prior run that wrote malformed
+    # entries — see GitHub issue #81).
     if grep -q "^# User-defined authentication rules" "${PG_HBA_CONF}"; then
-        bashio::log.debug "Removing existing user-defined rules before re-applying..."
+        bashio::log.debug "Removing existing user-defined rules..."
         sed -i '/^# User-defined authentication rules/,$d' "${PG_HBA_CONF}"
         # Remove any trailing blank lines left behind
         sed -i -e :a -e '/^[[:space:]]*$/{$d;N;ba}' "${PG_HBA_CONF}"
     fi
 
+    if ! bashio::config.has_value 'pg_hba_config'; then
+        return 0
+    fi
+
+    bashio::log.info "Applying pg_hba.conf authentication rules..."
+
     # Add a comment separator for user rules
     echo "" >> "${PG_HBA_CONF}"
     echo "# User-defined authentication rules" >> "${PG_HBA_CONF}"
-    
+
     # Get the number of rules
     local rule_count
     rule_count=$(bashio::config 'pg_hba_config | length')
-    
+
     # Process each rule
     for (( i=0; i<rule_count; i++ )); do
         local type database user address method options
         local rule_line
-        
-        # Get rule components
-        type=$(bashio::config "pg_hba_config[${i}].type" "host")
-        database=$(bashio::config "pg_hba_config[${i}].database" "")
-        user=$(bashio::config "pg_hba_config[${i}].user" "")
-        address=$(bashio::config "pg_hba_config[${i}].address" "")
-        method=$(bashio::config "pg_hba_config[${i}].method" "")
-        options=$(bashio::config "pg_hba_config[${i}].options" "")
-        
+
+        # Read rule components via optional_config so unset/null fields become
+        # true empty strings instead of the literal string "null".
+        type=$(optional_config "pg_hba_config[${i}].type" "host")
+        database=$(optional_config "pg_hba_config[${i}].database")
+        user=$(optional_config "pg_hba_config[${i}].user")
+        address=$(optional_config "pg_hba_config[${i}].address")
+        method=$(optional_config "pg_hba_config[${i}].method")
+        options=$(optional_config "pg_hba_config[${i}].options")
+
         # Validate required fields
         if [[ -z "${database}" ]] || [[ -z "${user}" ]] || [[ -z "${method}" ]]; then
             bashio::log.warning "Skipping invalid pg_hba rule ${i}: missing required field(s) (database, user, or method)"


### PR DESCRIPTION
## Proposed Changes

Two related bugs in `pg_hba_config` handling that together render the option unusable end-to-end:

### 1. The `null` write bug

`bashio::config "...options" ""` returns the literal string `"null"` (not an empty string) when the underlying JSON value is null, because bashio uses `local default=${2:-null}` internally — and `${2:-null}` collapses an empty-string default to `"null"`. The word `null` then gets appended as the options column of any user rule that doesn't explicitly set every optional field, and PostgreSQL refuses to load the file with:

```
authentication option not in name=value format: null
```

There is no PostgreSQL-accepted "no-op" value for the options column of `md5` / `scram-sha-256` rules (I checked PostgreSQL 17 source), so users cannot work around this purely from configuration — every IPv6 rule added via `pg_hba_config` ends up rejecting at reload.

Fixed by adding a small `optional_config` helper that uses `bashio::config.has_value` and returns a true empty string when the field is null/missing. All optional fields (`type`, `database`, `user`, `address`, `method`, `options`) now read through it.

### 2. Orphan rules left behind when `pg_hba_config` is cleared

The cleanup of previously-written user rules (`sed -i '/^# User-defined authentication rules/,$d' …`) was *inside* the `bashio::config.has_value 'pg_hba_config'` guard. So once a user had triggered bug 1 and tried to recover by clearing `pg_hba_config` in the UI, the broken `null` lines stayed in `pg_hba.conf` and PostgreSQL refused to start at all. Recovery required hand-editing `pg_hba.conf` inside the container.

This PR moves the cleanup above the `has_value` guard, and updates `init-addon/run` to always invoke `003_apply_user_config.sh` so cleanup runs even when both `postgresql_config` and `pg_hba_config` are empty.

## Effect for existing users

- New rules work correctly (no spurious `null` column).
- Anyone currently stuck in the broken state from bug 2 will be auto-recovered on the first restart with this version: the user-defined block is purged before any rule processing.
- No data-directory changes; this only affects the in-place rewrite of `pg_hba.conf`.

## Related Issues

Fixes #81